### PR TITLE
get it working with 4.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Then:
 ```bash	
 opam update
 opam upgrade
-opam switch 4.03.0
+opam switch 4.14.2
 eval `opam config env`
 opam install ocamlbuild ocamlfind ounit TCSLib extlib ocaml-sat-solvers minisat pgsolver
 git clone https://github.com/tcsprojects/mlsolver.git
 cd mlsolver
 ocaml setup.ml -configure
-ocaml setup.ml -build
+ocaml setup.ml -build -use-ocamlfind -tag thread -cflags -w,-31 -lflags -w,-31
 ```
 
 


### PR DESCRIPTION
Thank you very much, it is so nice to have a working tool where I can quickly check the validity of formulas in PDL or modal mu-calculus!

I added some build flags to get it running with the recent ocaml version 4.14.2.

Just for reference, I got an error with `opam switch create 4.03.0`:

<details>

```
$ opam switch create 4.03.0

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
Switch invariant: ["ocaml-base-compiler" {= "4.03.0"} | "ocaml-system" {= "4.03.0"}]

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved ocaml-config.1  (cached)
∗ installed base-bigarray.base
∗ installed base-threads.base
∗ installed base-unix.base
⬇ retrieved ocaml-base-compiler.4.03.0  (cached)
[ERROR] The compilation of ocaml-base-compiler.4.03.0 failed at "make world".

#=== ERROR while compiling ocaml-base-compiler.4.03.0 =========================#
# context     2.2.1 | linux/x86_64 |  | https://opam.ocaml.org#e0e4ef2cc7fe9e8d9d4e2d45331dbead54cb2bd2
# path        ~/.opam/4.03.0/.opam-switch/build/ocaml-base-compiler.4.03.0
# command     ~/.opam/opam-init/hooks/sandbox.sh build make world
# exit-code   2
# env-file    ~/.opam/log/ocaml-base-compiler-6339-1a267a.env
# output-file ~/.opam/log/ocaml-base-compiler-6339-1a267a.out
### output ###
# [...]
# -t "OCaml library" -man-mini \
# ../stdlib/*.mli ../parsing/*.mli ../otherlibs/unix/unix.mli ../otherlibs/str/str.mli ../otherlibs/bigarray/bigarray.mli ../otherlibs/num/num.mli
# Fatal error: exception Invalid_argument("inet_addr_of_string not implemented")
# make[4]: *** [Makefile:330: stdlib_man/Pervasives.3o] Error 2
# make[4]: Leaving directory '/home/lukas/.opam/4.03.0/.opam-switch/build/ocaml-base-compiler.4.03.0/ocamldoc'
...
```

This seems to be well-known and fixed in newer versions:

https://discuss.ocaml.org/t/building-ocaml-4-02-3-on-macos-big-sur/7127

<\details>